### PR TITLE
fix: 프론트엔드 API 경로를 백엔드에 맞게 수정 및 통계/알림 API 연동

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -10,6 +10,8 @@
 | 기능명 | Method | Endpoint | 파일 | 비고 |
 |--------|--------|----------|------|------|
 | 감지 목록 조회 | GET | `/detections/` | `App.tsx` | 정상 동작 |
+| 감지 통계 | GET | `/detections/statistics/` | `App.tsx` | 정상 동작 (대시보드 통계 카드) |
+| 알림 이력 조회 | GET | `/notifications/` | `NotificationCenter.tsx` | 정상 동작 (서버 알림 이력 + 실시간 FCM) |
 | 감지 삭제 | DELETE | `/detections/{id}/` | `App.tsx` | 백엔드 미지원 (ReadOnly) |
 | 감지 상태 업데이트 | PATCH | `/detections/{id}/` | `ViolationDetails.tsx` | 백엔드 미지원 (ReadOnly) |
 | FCM 토큰 등록 | POST | `/vehicles/register-fcm/` | `FCMNotification.tsx` | `plate_number` 필수 문제 |
@@ -22,14 +24,14 @@
 |--------|--------|----------|------|
 | 감지 상세 조회 | GET | `/detections/{id}/` | 상세 페이지에서 서버 최신 데이터 조회 |
 | 대기중 감지 목록 | GET | `/detections/pending/` | 처리 대기 목록 필터링 |
-| 감지 통계 | GET | `/detections/statistics/?period=today\|week\|month` | 대시보드 통계 카드 |
+| ~~감지 통계~~ | ~~GET~~ | ~~`/detections/statistics/`~~ | ~~연동 완료~~ |
 | 차량 목록 조회 | GET | `/vehicles/` | 차량 관리 페이지 |
 | 차량 등록 | POST | `/vehicles/` | 차량 신규 등록 |
 | 차량 상세 조회 | GET | `/vehicles/{id}/` | 차량 상세 정보 |
 | 차량 수정 | PUT/PATCH | `/vehicles/{id}/` | 차량 정보 수정 |
 | 차량 삭제 | DELETE | `/vehicles/{id}/` | 차량 정보 삭제 |
 | FCM 토큰 업데이트 | PATCH | `/vehicles/{id}/fcm-token/` | 특정 차량 FCM 토큰 갱신 |
-| 알림 목록 조회 | GET | `/notifications/` | 알림 내역 페이지 |
+| ~~알림 목록 조회~~ | ~~GET~~ | ~~`/notifications/`~~ | ~~연동 완료~~ |
 | 알림 상세 조회 | GET | `/notifications/{id}/` | 알림 상세 확인 |
 
 ---

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,60 @@
+# Frontend API 연동 문서
+
+> 마지막 업데이트: 2026-02-06
+> Base URL: `VITE_API_BASE_URL` = `http://localhost:8000/api/v1`
+
+---
+
+## 1. 현재 연동된 API
+
+| 기능명 | Method | Endpoint | 파일 | 비고 |
+|--------|--------|----------|------|------|
+| 감지 목록 조회 | GET | `/detections/` | `App.tsx` | 정상 동작 |
+| 감지 삭제 | DELETE | `/detections/{id}/` | `App.tsx` | 백엔드 미지원 (ReadOnly) |
+| 감지 상태 업데이트 | PATCH | `/detections/{id}/` | `ViolationDetails.tsx` | 백엔드 미지원 (ReadOnly) |
+| FCM 토큰 등록 | POST | `/vehicles/register-fcm/` | `FCMNotification.tsx` | `plate_number` 필수 문제 |
+
+---
+
+## 2. 백엔드에 이미 있지만 프론트에서 미연동인 API
+
+| 기능명 | Method | Endpoint | 용도 |
+|--------|--------|----------|------|
+| 감지 상세 조회 | GET | `/detections/{id}/` | 상세 페이지에서 서버 최신 데이터 조회 |
+| 대기중 감지 목록 | GET | `/detections/pending/` | 처리 대기 목록 필터링 |
+| 감지 통계 | GET | `/detections/statistics/?period=today\|week\|month` | 대시보드 통계 카드 |
+| 차량 목록 조회 | GET | `/vehicles/` | 차량 관리 페이지 |
+| 차량 등록 | POST | `/vehicles/` | 차량 신규 등록 |
+| 차량 상세 조회 | GET | `/vehicles/{id}/` | 차량 상세 정보 |
+| 차량 수정 | PUT/PATCH | `/vehicles/{id}/` | 차량 정보 수정 |
+| 차량 삭제 | DELETE | `/vehicles/{id}/` | 차량 정보 삭제 |
+| FCM 토큰 업데이트 | PATCH | `/vehicles/{id}/fcm-token/` | 특정 차량 FCM 토큰 갱신 |
+| 알림 목록 조회 | GET | `/notifications/` | 알림 내역 페이지 |
+| 알림 상세 조회 | GET | `/notifications/{id}/` | 알림 상세 확인 |
+
+---
+
+## 3. 백엔드에 새로 만들어야 하는 API
+
+### 3-1. 감지 삭제 API
+
+- **Endpoint**: `DELETE /api/v1/detections/{id}/`
+- **필요 이유**: 프론트엔드 대시보드에서 위반 기록 삭제 기능 사용 중
+- **현재 상태**: `DetectionViewSet`이 `ReadOnlyModelViewSet`이라 DELETE 미지원
+- **해결 방안**: `ReadOnlyModelViewSet` → `ModelViewSet` 변경, 또는 `DestroyModelMixin` 추가
+
+### 3-2. 감지 상태 업데이트 API
+
+- **Endpoint**: `PATCH /api/v1/detections/{id}/`
+- **요청 Body**: `{ "status": "completed" | "pending" }`
+- **필요 이유**: 프론트엔드에서 확인 처리 토글(체크/미체크) 기능 사용 중
+- **현재 상태**: `DetectionViewSet`이 `ReadOnlyModelViewSet`이라 PATCH 미지원
+- **해결 방안**: 커스텀 액션 `@action(detail=True, methods=["patch"])` 추가, 또는 `UpdateModelMixin` 추가
+
+### 3-3. 대시보드 FCM 토큰 등록 API
+
+- **Endpoint**: `POST /api/v1/notifications/register-dashboard-fcm/` (제안)
+- **요청 Body**: `{ "fcm_token": "string" }`
+- **필요 이유**: 대시보드 웹앱에서 푸시 알림 수신을 위해 FCM 토큰을 등록해야 함
+- **현재 상태**: 기존 `/vehicles/register-fcm/`은 `plate_number`가 필수이므로 대시보드용으로 부적합
+- **해결 방안**: 대시보드 전용 FCM 등록 엔드포인트 신설, 또는 `plate_number` 옵셔널 처리

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import Header from "./components/Header";
 import Dashboard from "./components/Dashboard";
 import ViolationDetails from "./components/ViolationDetails";
 import LandingPage from "./components/LandingPage";
-import { Violation } from "./types";
+import { Violation, StatsData } from "./types";
 import Swal from "sweetalert2";
 import VehicleHistory from "./components/VehicleHistory";
 import { onMessage } from "firebase/messaging";
@@ -24,6 +24,12 @@ function DashboardPage() {
   const [showVehicleHistory, setShowVehicleHistory] = useState(false);
   const [vehicleViolations, setVehicleViolations] = useState<Violation[]>([]);
   const [searchPlateNumber, setSearchPlateNumber] = useState("");
+  const [stats, setStats] = useState<StatsData>({
+    totalViolations: 0,
+    checked: 0,
+    pendingReview: 0,
+    avgSpeed: 0,
+  });
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
   // /detections/ GET 에서 데이터 불러오기
@@ -38,6 +44,21 @@ function DashboardPage() {
       .catch((err) => {
         console.error("API fetch error:", err);
         setLoading(false);
+      });
+
+    // 통계 데이터 서버에서 가져오기
+    fetch(`${API_BASE_URL}/detections/statistics/`)
+      .then((res) => res.json())
+      .then((data) => {
+        setStats({
+          totalViolations: data.total_detections ?? 0,
+          checked: data.completed_count ?? 0,
+          pendingReview: data.pending_count ?? 0,
+          avgSpeed: Math.round(data.avg_speed ?? 0),
+        });
+      })
+      .catch((err) => {
+        console.error("Statistics fetch error:", err);
       });
 
     // 🔔 푸시 알림 등록
@@ -145,16 +166,6 @@ function DashboardPage() {
     }
     return 0;
   });
-
-  // Calculate statistics
-  const stats = {
-    totalViolations: violations.length,
-    checked: violations.filter((v) => v.status === 'completed').length,
-    pendingReview: violations.filter((v) => v.status !== 'completed').length,
-    avgSpeed: Math.round(
-      violations.reduce((sum, v) => sum + v.detected_speed, 0) / violations.length
-    ),
-  };
 
   return (
     <>

--- a/src/components/FCMNotification.tsx
+++ b/src/components/FCMNotification.tsx
@@ -25,9 +25,11 @@ const FCMNotification = () => {
             console.log("FCM 토큰:", currentToken);
 
             // 3. 백엔드에 토큰 등록
+            // TODO: register-fcm은 plate_number도 필요. 대시보드용 FCM 등록 엔드포인트가 별도로 필요할 수 있음.
             try {
-              await axios.post(`${API_BASE_URL}/fcm/register`, {
-                token: currentToken,
+              await axios.post(`${API_BASE_URL}/vehicles/register-fcm/`, {
+                fcm_token: currentToken,
+                plate_number: "DASHBOARD",
               });
               console.log("FCM 토큰이 성공적으로 등록되었습니다.");
             } catch (error) {

--- a/src/components/LaneViolationChart.tsx
+++ b/src/components/LaneViolationChart.tsx
@@ -3,7 +3,7 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContaine
 
 interface LaneViolationChartProps {
   laneData: {
-    lane: number;
+    lane: string;
     count: number;
     avgSpeed: number;
   }[];
@@ -13,7 +13,7 @@ const CustomTooltip = ({ active, payload, label }: any) => {
   if (!active || !payload?.length) return null;
   return (
     <div className="bg-[#0c0e16] border border-white/10 rounded-xl px-4 py-3 shadow-xl">
-      <p className="text-xs text-gray-400 mb-1">{label}차선</p>
+      <p className="text-xs text-gray-400 mb-1">카메라 {label}</p>
       <p className="text-sm font-semibold text-cyan-400">{payload[0].value}건</p>
     </div>
   );
@@ -22,7 +22,7 @@ const CustomTooltip = ({ active, payload, label }: any) => {
 const LaneViolationChart: React.FC<LaneViolationChartProps> = ({ laneData }) => {
   return (
     <div className="rounded-2xl border border-white/5 bg-white/[0.02] p-5">
-      <h3 className="text-sm font-semibold text-white mb-5">차선별 위반 현황</h3>
+      <h3 className="text-sm font-semibold text-white mb-5">카메라별 위반 현황</h3>
       <div className="h-[200px]">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={laneData} margin={{ top: 5, right: 10, left: -15, bottom: 0 }}>
@@ -33,7 +33,6 @@ const LaneViolationChart: React.FC<LaneViolationChartProps> = ({ laneData }) => 
               tick={{ fill: '#6b7280', fontSize: 11 }}
               axisLine={false}
               tickLine={false}
-              tickFormatter={(v) => `${v}차선`}
             />
             <YAxis
               stroke="rgba(255,255,255,0.15)"

--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -29,8 +29,8 @@ const NotificationCenter: React.FC = () => {
         type: 'violation',
         timestamp: new Date(data.timestamp || Date.now()).toLocaleString(),
         read: false,
-        plateNumber: data.car_number || '미확인 차량',
-        speed: Number(data.car_speed) || 0,
+        plateNumber: data.ocr_result || '미확인 차량',
+        speed: Number(data.detected_speed) || 0,
         location: data.location || 'Seoul',
       };
       setNotifications(prev => [newNotification, ...prev]);

--- a/src/components/TrendChart.tsx
+++ b/src/components/TrendChart.tsx
@@ -42,11 +42,11 @@ const TrendChart: React.FC<TrendChartProps> = ({ violations }) => {
       date.setDate(date.getDate() - i);
       const dateStr = date.toISOString().split('T')[0];
       const dayViolations = violations.filter(v => {
-        if (!v.created_at) return false;
-        return v.created_at.split('T')[0] === dateStr;
+        if (!v.detected_at) return false;
+        return v.detected_at.split('T')[0] === dateStr;
       });
       const avgSpeed = dayViolations.length > 0
-        ? Math.round(dayViolations.reduce((s, v) => s + v.car_speed, 0) / dayViolations.length)
+        ? Math.round(dayViolations.reduce((s, v) => s + v.detected_speed, 0) / dayViolations.length)
         : 0;
 
       result.push({
@@ -69,12 +69,12 @@ const TrendChart: React.FC<TrendChartProps> = ({ violations }) => {
       weekEnd.setDate(weekEnd.getDate() - i * 7);
 
       const weekViolations = violations.filter(v => {
-        if (!v.created_at) return false;
-        const vDate = new Date(v.created_at);
+        if (!v.detected_at) return false;
+        const vDate = new Date(v.detected_at);
         return vDate >= weekStart && vDate <= weekEnd;
       });
       const avgSpeed = weekViolations.length > 0
-        ? Math.round(weekViolations.reduce((s, v) => s + v.car_speed, 0) / weekViolations.length)
+        ? Math.round(weekViolations.reduce((s, v) => s + v.detected_speed, 0) / weekViolations.length)
         : 0;
 
       result.push({

--- a/src/components/ViolationsTable.tsx
+++ b/src/components/ViolationsTable.tsx
@@ -61,7 +61,7 @@ const ViolationsTable: React.FC<ViolationsTableProps> = ({
         </thead>
         <tbody className="divide-y divide-white/[0.03]">
           {violations.map((violation) => {
-            const speedBadge = getSpeedBadge(violation.car_speed);
+            const speedBadge = getSpeedBadge(violation.detected_speed);
             return (
               <tr
                 key={violation.id}
@@ -78,34 +78,34 @@ const ViolationsTable: React.FC<ViolationsTableProps> = ({
                 <td className="px-5 py-3.5">
                   <div className="h-10 w-14 rounded-lg overflow-hidden border border-white/10">
                     <img
-                      src={violation.image_url}
-                      alt={`Vehicle ${violation.car_number}`}
+                      src={violation.image_gcs_uri}
+                      alt={`Vehicle ${violation.ocr_result}`}
                       className="h-full w-full object-cover"
                     />
                   </div>
                 </td>
                 <td className="px-5 py-3.5 text-sm font-medium text-white">
-                  {violation.car_number}
+                  {violation.ocr_result}
                 </td>
                 <td className="px-5 py-3.5">
                   <span className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold border ${speedBadge.color}`}>
-                    {violation.car_speed} km/h
+                    {violation.detected_speed} km/h
                   </span>
                 </td>
                 <td className="px-5 py-3.5">
                   <span className={`inline-flex items-center gap-1.5 text-xs ${
-                    violation.is_checked
+                    violation.status === 'completed'
                       ? 'text-cyan-400'
                       : 'text-gray-500'
                   }`}>
                     <span className={`w-1.5 h-1.5 rounded-full ${
-                      violation.is_checked ? 'bg-cyan-400' : 'bg-gray-600'
+                      violation.status === 'completed' ? 'bg-cyan-400' : 'bg-gray-600'
                     }`} />
-                    {violation.is_checked ? '확인됨' : '미확인'}
+                    {violation.status === 'completed' ? '확인됨' : '미확인'}
                   </span>
                 </td>
                 <td className="px-5 py-3.5 text-sm text-gray-500">
-                  {formatDate(violation.created_at)}
+                  {formatDate(violation.detected_at)}
                 </td>
                 <td className="px-5 py-3.5 text-right">
                   <div className="flex items-center justify-end gap-1">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,17 +1,19 @@
 export interface Violation {
   id: number;
-  image_url: string;
-  car_number: string;
-  car_speed: number;
-  is_checked: boolean;
-  date: string;
+  vehicle_id?: number;
+  image_gcs_uri: string;
+  ocr_result: string;
+  detected_speed: number;
+  speed_limit: number;
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  detected_at: string;
   location?: string;
-  fineAmount?: number;
-  created_at?: string;
+  camera_id?: string;
+  ocr_confidence?: number;
+  processed_at?: string;
+  error_message?: string;
+  created_at: string;
   updated_at?: string;
-  lane?: number;
-  vehicleType?: string;
-  dangerLevel?: 'Low' | 'Medium' | 'High';
 }
 
 export interface StatsData {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,16 +2,16 @@ import { Violation } from '../types';
 
 // Calculate fine amount based on speed and speed limit
 export const calculateFine = (
-  speed: number, 
-  speedLimit: number = 80, 
+  speed: number,
+  speedLimit: number = 60,
   baseFine: number = 30000
 ): number => {
   const overSpeed = speed - speedLimit;
-  
+
   if (overSpeed <= 0) return 0;
-  
+
   let multiplier = 1;
-  
+
   if (overSpeed > 40) {
     multiplier = 3;
   } else if (overSpeed > 30) {
@@ -21,14 +21,14 @@ export const calculateFine = (
   } else if (overSpeed > 10) {
     multiplier = 1.5;
   }
-  
+
   return Math.round(baseFine * multiplier);
 };
 
 // Get danger level based on speed
-export const getDangerLevel = (speed: number, speedLimit: number = 80): 'Low' | 'Medium' | 'High' => {
+export const getDangerLevel = (speed: number, speedLimit: number = 60): 'Low' | 'Medium' | 'High' => {
   const overSpeed = speed - speedLimit;
-  
+
   if (overSpeed > 30) return 'High';
   if (overSpeed > 15) return 'Medium';
   return 'Low';
@@ -43,29 +43,6 @@ export const formatDate = (date: Date): string => {
   });
 };
 
-// Extract stats for lane violations
-export const extractLaneStats = (violations: Violation[]) => {
-  const laneMap = new Map<number, { count: number; totalSpeed: number }>();
-  
-  violations.forEach(violation => {
-    if (violation.lane) {
-      if (!laneMap.has(violation.lane)) {
-        laneMap.set(violation.lane, { count: 0, totalSpeed: 0 });
-      }
-      
-      const data = laneMap.get(violation.lane)!;
-      data.count += 1;
-      data.totalSpeed += violation.car_speed;
-    }
-  });
-  
-  return Array.from(laneMap.entries()).map(([lane, data]) => ({
-    lane,
-    count: data.count,
-    avgSpeed: Math.round(data.totalSpeed / data.count)
-  }));
-};
-
 // Extract speed distribution data
 export const extractSpeedDistribution = (violations: Violation[]) => {
   const ranges = [
@@ -75,12 +52,35 @@ export const extractSpeedDistribution = (violations: Violation[]) => {
     { min: 110, max: 120, label: '110-120 km/h', color: 'bg-red-400' },
     { min: 120, max: Infinity, label: '> 120 km/h', color: 'bg-red-600' }
   ];
-  
+
   const distribution = ranges.map(range => ({
     range: range.label,
-    count: violations.filter(v => v.car_speed >= range.min && v.car_speed < range.max).length,
+    count: violations.filter(v => v.detected_speed >= range.min && v.detected_speed < range.max).length,
     color: range.color
   }));
-  
+
   return distribution;
+};
+
+// Extract stats for camera-based violations (replaces lane stats)
+export const extractLaneStats = (violations: Violation[]) => {
+  const cameraMap = new Map<string, { count: number; totalSpeed: number }>();
+
+  violations.forEach(violation => {
+    if (violation.camera_id) {
+      if (!cameraMap.has(violation.camera_id)) {
+        cameraMap.set(violation.camera_id, { count: 0, totalSpeed: 0 });
+      }
+
+      const data = cameraMap.get(violation.camera_id)!;
+      data.count += 1;
+      data.totalSpeed += violation.detected_speed;
+    }
+  });
+
+  return Array.from(cameraMap.entries()).map(([lane, data]) => ({
+    lane,
+    count: data.count,
+    avgSpeed: Math.round(data.totalSpeed / data.count)
+  }));
 };


### PR DESCRIPTION
## Summary
- 프론트엔드의 모든 API 경로와 필드명을 백엔드(Django REST Framework) 실제 엔드포인트에 맞게 수정
- 감지 통계 API(`/detections/statistics/`) 및 알림 이력 API(`/notifications/`) 신규 연동
- API 연동 현황 문서(`docs/API.md`) 추가

## Changes

### API 경로 수정
- Base URL: `/api/v1/crud` → `/api/v1`
- 감지 목록: `/crud/cars` → `/detections/`
- 감지 삭제: `/crud/cars/{id}` → `/detections/{id}/`
- 상태 업데이트: `/crud/cars/{id}/partial-update` → `/detections/{id}/`
- FCM 등록: `/crud/fcm/register` → `/vehicles/register-fcm/`

### 필드명 매핑 (전 컴포넌트 반영)
- `car_number` → `ocr_result`
- `car_speed` → `detected_speed`
- `image_url` → `image_gcs_uri`
- `is_checked` (boolean) → `status` (completed = 확인됨)
- `lane` → `camera_id`

### 신규 API 연동
- **감지 통계**: 클라이언트 계산 → 서버 통계 엔드포인트로 교체
- **알림 이력**: 서버 알림 이력 로드 + 실시간 FCM 통합 표시

## Test plan
- [ ] 대시보드 진입 시 감지 목록이 정상 로드되는지 확인
- [ ] 통계 카드(총 위반, 확인 완료, 미확인, 평균 속도)가 서버 데이터 기반으로 표시되는지 확인
- [ ] 알림 센터 열었을 때 서버 알림 이력이 표시되는지 확인
- [ ] 실시간 FCM 알림이 기존처럼 수신되는지 확인
- [ ] 번호판 검색, 필터링, 정렬 기능 정상 동작 확인