### PR TITLE
fix: 랜딩 페이지 3D 토글, 스크롤 잠금, 로고 클릭 수정

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -21,10 +21,21 @@ function LandingPage() {
   const heroRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const handleScroll = () => setScrollY(window.scrollY);
+    const handleScroll = () => {
+      const y = window.scrollY;
+      setScrollY(y);
+      if (y > 600) setIs3DMode(false);
+    };
     window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
+
+  useEffect(() => {
+    document.body.style.overflow = is3DMode ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [is3DMode]);
 
   const heroOpacity = Math.max(0, 1 - scrollY / 600);
   const heroScale = 1 + scrollY * 0.0003;
@@ -40,7 +51,13 @@ function LandingPage() {
               : ""
           }`}
         >
-          <div className="flex items-center gap-3">
+          <div
+            className="flex items-center gap-3 cursor-pointer"
+            onClick={() => {
+              window.scrollTo({ top: 0, behavior: 'smooth' });
+              setIs3DMode(false);
+            }}
+          >
             <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-cyan-400 to-blue-500 flex items-center justify-center">
               <Radar className="w-5 h-5 text-white" />
             </div>
@@ -143,9 +160,11 @@ function LandingPage() {
         <button
           onClick={() => setIs3DMode(!is3DMode)}
           className={`fixed bottom-8 right-8 z-50 flex items-center gap-2 px-5 py-3 rounded-full text-sm font-medium transition-all duration-500 shadow-2xl ${
-            is3DMode
-              ? "bg-cyan-500 text-white shadow-cyan-500/30"
-              : "bg-white/10 backdrop-blur-md text-white border border-white/15 hover:bg-white/20"
+            scrollY > 600
+              ? "opacity-0 pointer-events-none"
+              : is3DMode
+                ? "bg-cyan-500 text-white shadow-cyan-500/30"
+                : "bg-white/10 backdrop-blur-md text-white border border-white/15 hover:bg-white/20"
           }`}
         >
           <MousePointer className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- 3D 차량 조작 버튼이 히어로 섹션 이외에서도 표시되던 문제 수정 (scrollY > 600 시 숨김)
- 3D 모드 활성화 시 스크롤 잠금, 복귀 시 스크롤 해제
- 네비게이션 바 로고(AutoNotify) 클릭 시 페이지 상단으로 스무스 스크롤

## Test plan
- [ ] 랜딩 페이지에서 스크롤 시 3D 조작 버튼이 히어로 섹션 밖에서 사라지는지 확인
- [ ] 3D 모드 활성화 시 스크롤이 잠기는지 확인
- [ ] 스크롤 모드 복귀 시 스크롤이 정상 동작하는지 확인
- [ ] 네비게이션 로고 클릭 시 페이지 상단으로 이동하는지 확인